### PR TITLE
use gulp from node_modules, rather than global one

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "watchify": "^3.9.0"
   },
   "scripts": {
-    "start": "gulp js && node index.js"
+    "start": "./node_modules/gulp-cli/bin/gulp.js js && node index.js"
   }
 }


### PR DESCRIPTION
this is helpful because developers' will not need to manually install `gulp` globally. (All dependencies will be installed via `yarn install`)